### PR TITLE
monospace font

### DIFF
--- a/template_header.tex
+++ b/template_header.tex
@@ -57,8 +57,9 @@
   commentstyle=\color{dkgreen},
   stringstyle=\color{mauve},
   breaklines=true,
-  breakatwhitespace=true
-  tabsize=2
+  breakatwhitespace=true,
+  tabsize=2,
+  keepspaces=true,
 }
 
 \setlength{\columnsep}{0.5in}


### PR DESCRIPTION
https://en.wikibooks.org/wiki/LaTeX/Source_Code_Listings#Settings

>   keepspaces=true,                 % keeps spaces in text, useful for keeping indentation of code (possibly needs columns=flexible)
